### PR TITLE
`install-sh` fix

### DIFF
--- a/dune
+++ b/dune
@@ -114,10 +114,10 @@
  (libraries stdcompat))
 
 (rule
- (action (copy stdcompat__native.ml_native stdcompat__native.ml)))
+ (copy stdcompat__native.ml_native stdcompat__native.ml))
 
 (rule
- (action (copy stdcompat__init.mli.in stdcompat__init.ml.in)))
+ (copy stdcompat__init.mli.in stdcompat__init.ml.in))
 
 (rule
  (targets

--- a/dune
+++ b/dune
@@ -114,14 +114,10 @@
  (libraries stdcompat))
 
 (rule
- (target stdcompat__native.ml)
- (deps stdcompat__native.ml_native)
- (action (copy %{deps} %{target})))
+ (action (copy stdcompat__native.ml_native stdcompat__native.ml)))
 
 (rule
- (target stdcompat__init.ml.in)
- (deps stdcompat__init.mli.in)
- (action (copy %{deps} %{target})))
+ (action (copy stdcompat__init.mli.in stdcompat__init.ml.in)))
 
 (rule
  (targets

--- a/dune
+++ b/dune
@@ -124,7 +124,9 @@
  (action (copy %{deps} %{target})))
 
 (rule
- (target configure)
+ (targets
+   configure
+   install-sh)
  (deps
   META.in
   Makefile.am
@@ -495,5 +497,6 @@
   stdcompat__weak.mli
   stdcompat__weak_s.ml
   stdcompat__weak_s.mli)
-  (deps (:configure configure))
+  (deps (:configure configure)
+        install-sh)
   (action (run %{configure})))


### PR DESCRIPTION
@emillon found another issue, that `configure` depends on `install-sh` (which is generated by `autoreconf`) but we never declare it as target nor dependency, so this PR fixes it.

It also simplifies the copy rules further.